### PR TITLE
Add image for Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -1,0 +1,15 @@
+# maintainer: Michael Babker <michael.babker@joomla.org> (@mbabker)
+
+3.4.3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4.3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3.4: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3-apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+apache: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+3: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+latest: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c apache
+
+3.4.3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+3.4-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+3-fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm
+fpm: git://github.com/joomla/docker-joomla@966275ada2148e343a68c8c03870f11cc7f5b89c fpm


### PR DESCRIPTION
This PR adds a Docker image for the Joomla! CMS

Docs PR: https://github.com/docker-library/docs/pull/293